### PR TITLE
[Docs] Update README with current architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,208 @@
 # Verancial
 
-Verancial is a service that helps users manage their financial information. It allows users to securely download, store, and process their financial information from banks. This information can be used for data analysis and exporting reports to popular financial apps like BudgetBakers and YNAB.
+Verancial is a personal finance application that ingests bank statement
+exports (CSV files from supported banks), normalizes and de-duplicates the
+transactions, auto-categorizes them, and stores them per user. From there it
+can generate export reports for third-party budgeting apps — currently
+[BudgetBakers](https://budgetbakers.com/) — so a user's bank transactions
+show up in their budgeting tool of choice.
 
-## Installation
+Supported banks today (see `shared/constants`): Scotiabank (chequing and
+credit card), Nubank, Wise, and First Tech Federal Credit Union (chequing and
+credit card).
 
-To run Verancial, you'll need to have the following tools installed:
+## Architecture
 
-- Docker
-- Go 1.18
+The system is a Go monorepo with one React frontend, three Go backend
+services, a shared Go module, a Postgres/Supabase database, a Redis-backed
+task queue, and a couple of standalone Python/Node automation scripts.
 
-Once you have these installed, follow these steps:
+### Services
 
-1. Clone the repository:
+- **`api/`** — the main REST API (Gin), used by the frontend. Routes live
+  under `/api/v0`:
+  - `POST /report/process` — kicks off transaction-report processing
+  - `POST /app-integration/generate` — kicks off a BudgetBakers export
+  - `GET /dashboard/user` — dashboard stats for the logged-in user
+  - `GET /transaction/list/:bankId` — list transactions for a bank
+  - `GET /bank/:bankId` — bank account stats
+  All routes are behind JWT auth middleware (`shared/auth`).
 
-    ```
-    git clone https://github.com/verasthiago/verancial.git
-    ```
+- **`login/`** — authentication service (Gin), routes under `/login/v0`:
+  - `POST /user/signin`, `POST /user/signup` (public)
+  - `DELETE /admin/delete`, `PUT /admin/update` (JWT-protected)
+  Issues/validates JWTs, hashes passwords with bcrypt.
 
-2. Navigate to the project root directory:
+- **`data-process-worker/`** — parses uploaded bank CSV exports into
+  `models.Transaction` rows. Each bank has its own parser under
+  `pkg/models/<bank>` and `pkg/report/<bank>`. It de-duplicates using a
+  transaction fingerprint and runs transactions through a rule-based
+  category guesser (`pkg/category-guesser`, backed by
+  `pre_defined_categories.json`) before bulk-inserting into Postgres.
 
-    ```
-    cd verancial
-    ```
+- **`app-integration-worker/`** — generates and submits export reports to
+  external finance apps. Currently implements a BudgetBakers generator
+  (`pkg/generators/budgetbakers`) that builds a CSV report from a user's
+  transactions for upload/import into BudgetBakers.
 
-3. Run the database migrations:
+Both workers can run in two modes, controlled by an `AsyncProcessing` flag:
+- **Sync mode**: exposed as a small Gin HTTP endpoint
+  (`/dpw/v0/process_report`, `/aiw/v0/process_app_report`) that runs the job
+  inline.
+- **Async mode** (the queue-based path): an [asynq](https://github.com/hibiken/asynq)
+  worker listening on Redis queues (`critical`/`default`/`low`).
 
-    ```
-    make migrate_db
-    ```
+The `api` service enqueues work onto Redis via `shared/task` (`AsyncQueue`),
+using task patterns defined in `shared/types` (`PatternReportProcess`,
+`PatternAppIntegration`). The two workers consume those tasks asynchronously
+— this is the primary inter-service communication mechanism, not synchronous
+REST calls between services.
 
-4. Build and run the services using the Makefile:
+### Shared module (`shared/`)
 
-    ```
-    make all_build
-    ```
+Common Go code imported by all four services:
+- `auth` — JWT creation/validation
+- `constants` — bank IDs and other shared constants
+- `errors` — Gin error-handling helpers (`ErrorRoute`)
+- `flags` — env-based configuration loading (`VERANCIAL_DEPLOY_ENV`-driven)
+- `models` — `User`, `Transaction`, `BankAccount`, `BankCredentials`,
+  `FinancialAppCredentials`, `BudgetBakers` (export row), dashboard DTOs
+- `repository` — data-access interface, with a Postgres implementation in
+  `repository/postgresRepository` (users, transactions, bank accounts)
+- `scripts` — Mage-based DB migration scripts (`mage.go`) and local dev
+  helper scripts
+- `task` — the asynq-based task/queue client (`Task` interface,
+  `AsyncQueue`)
+- `types` — queue payload types and task pattern names
+- `validator` — shared request validation
 
-5. Access the application:
-    - Frontend: http://localhost:3000
-    - API: http://localhost:8080
-    - Login: http://localhost:8081
+### Database
 
-## Services
+Postgres, hosted on [Supabase](https://supabase.com/). SQL migrations live
+in `migrations/`:
+- `run_migrations.sql` — creates `users` and `transactions` tables, with
+  Row Level Security policies (per-user access plus a service-role bypass)
+- `002_create_bank_accounts.sql` — creates `bank_accounts` (supported banks)
+  and `user_bank_accounts` (per-user bank connections), also RLS-protected
 
-Verancial is a monorepo consisting of the following services:
+Local Postgres via docker-compose has been removed in favor of Supabase;
+the commented-out block in `docker-compose.yaml` shows how to bring a local
+Postgres container back if needed.
+
+### Queue
+
+Redis (`worker-redis` in docker-compose, port 6379) backs the asynq task
+queue used for async report processing and app-integration jobs.
 
 ### Frontend
 
-The Frontend service is a React TypeScript application that provides a modern web interface for users to:
-- Login securely with JWT authentication
-- View dashboard with bank account statistics
-- See transaction counts and data freshness for each connected bank
-- Manage bank account connections
+`frontend/` — React 18 + TypeScript, bootstrapped with Create React App via
+CRACO. Key pieces under `frontend/src`:
+- `components/Login.tsx`, `Dashboard.tsx`, `Bank.tsx`
+- `services/api.ts` — Axios client for the `api` service
+Served on port 3000; talks to the `api` (8080) and `login` (8081) services.
 
-### API
+### Python / Node automation scripts
 
-The API service provides an interface for accessing and managing user financial data, including:
-- Dashboard statistics endpoints
-- Bank account management
-- Transaction data processing
+`python-scripts/` (not part of the Docker stack, run manually):
+- `get_last_transaction_budgetbakers.py` — Selenium script that logs into
+  BudgetBakers' web UI and reads back the last imported transaction date, so
+  the app-integration worker knows where to resume exporting from
+- `convertBRLToAnyCurrency_Budget.js` — currency conversion helper for BRL
+- `requirements.txt` — Python deps (Selenium, webdriver-manager, etc.)
 
-### Login
+## Running locally
 
-The Login service provides user authentication and authorization functionality.
+Requirements: Docker, Go 1.18+, Node (for frontend dev), and a Supabase
+Postgres instance (connection configured via env vars consumed by
+`shared/flags`).
 
-### Shared
+### Full stack via Docker Compose
 
-The Shared folder contains Go code that is shared across all services.
+```
+make all          # docker-compose up
+make all_build     # docker-compose up --build
+```
+
+This brings up `api` (:8080), `login` (:8081), `frontend` (:3000), and
+`worker-redis` (:6379). `data-process-worker` and `app-integration-worker`
+are not in `docker-compose.yaml` — run them locally (see below) or add
+services for them as needed.
+
+### Running services individually (Go, local)
+
+```
+make start_api_local                       # api on :8080
+make start_login_local                     # login on :8081
+make start_report_process_worker_local     # data-process-worker
+make start_app_integration_worker_local    # app-integration-worker
+make start_frontend_local                  # frontend via npm run dev
+make start_redis                           # just Redis, via docker-compose
+```
+
+Each `*_local` target sets `VERANCIAL_DEPLOY_ENV=local` and runs `go run
+main.go` directly from the service directory, picking up local env config
+files via `shared/flags`.
+
+### Database migrations
+
+```
+make migrate_db
+```
+
+Runs the Mage-based migration scripts in `shared/scripts` against the
+configured (local) database: `migrateUserModel` and
+`migrateTransactionModel`. For Supabase, you can alternatively run the SQL
+in `migrations/run_migrations.sql` and `migrations/002_create_bank_accounts.sql`
+directly in the Supabase SQL editor.
+
+## Directory structure
+
+```
+api/                      REST API service (Gin) — frontend-facing
+  cmd/server/              entrypoint wiring (flags, builder)
+  pkg/builder/             dependency/config builder
+  pkg/handlers/            route handlers (dashboard, bank, report, app-integration)
+  pkg/handlers/transaction/ transaction listing handler
+  pkg/middlewares/         auth middleware
+  pkg/validator/           request validation
+
+login/                    Auth service (Gin)
+  pkg/handlers/             sign-up/sign-in/update/delete
+  pkg/middlewares/          auth middleware
+  pkg/constants/, pkg/validator/
+
+data-process-worker/      Bank CSV ingestion + categorization (sync HTTP or asynq worker)
+  pkg/models/<bank>/        per-bank CSV row models
+  pkg/report/<bank>/        per-bank CSV parsing/processing logic
+  pkg/category-guesser/     rule-based transaction categorization
+  pkg/handlers/, pkg/helper/, pkg/builder/
+
+app-integration-worker/   Export-to-third-party-app worker (sync HTTP or asynq worker)
+  pkg/generators/budgetbakers/  BudgetBakers CSV report generator
+  pkg/generators/helper/
+  pkg/handlers/, pkg/types/, pkg/builder/
+
+shared/                   Shared Go module used by all services
+  auth/, constants/, errors/, flags/, models/, types/, validator/
+  repository/                data-access interface + postgresRepository implementation
+  task/                       asynq queue client
+
+frontend/                 React + TypeScript SPA (CRACO/CRA)
+  src/components/           Login, Dashboard, Bank views
+  src/services/             API client (Axios)
+
+migrations/                Supabase/Postgres SQL migrations (users, transactions,
+                            bank_accounts, user_bank_accounts + RLS policies)
+
+python-scripts/            Standalone Selenium/Node helper scripts (BudgetBakers
+                            last-transaction lookup, BRL currency conversion)
+
+docker-compose.yaml         api, login, frontend, worker-redis
+makefile                    local dev / docker / migration targets
+```
 
 ## Contributing
-
-We welcome contributions to Verancial. To contribute:
 
 1. Open an issue to discuss your changes.
 2. Fork the repository.
@@ -80,8 +213,4 @@ We welcome contributions to Verancial. To contribute:
 
 ## Contact
 
-If you have any questions or concerns, you can reach us at `verancial@verasthiago.com` or on LinkedIn at https://www.linkedin.com/in/verasthiago/.
-
-## Future Plans
-
-We plan to add a CLI in the near future, and possibly a frontend. We're also working on a new service that's currently in development. Stay tuned for more updates!
+`verancial@verasthiago.com` or https://www.linkedin.com/in/verasthiago/.


### PR DESCRIPTION
## Summary
- Rewrites `README.md` based on a thorough read of the actual codebase (main.go and pkg/ in api, login, data-process-worker, app-integration-worker; shared/ module; migrations/*.sql; docker-compose.yaml; makefile; python-scripts).
- Documents what the project actually does: bank CSV statement ingestion, transaction de-duplication/categorization, and BudgetBakers export generation (no YNAB integration in the code, so that claim was removed).
- Documents the real architecture: 4 Go services (api, login, data-process-worker, app-integration-worker), the shared Go module, asynq/Redis as the queue-based communication mechanism between `api` and the two workers (each worker also supports a sync HTTP mode), Postgres on Supabase with RLS policies, and the React + TypeScript (CRACO) frontend.
- Replaces the old "Installation" section with accurate `make`/docker-compose instructions reflecting the actual makefile targets and docker-compose services.
- Adds a directory structure overview.
- Removes stale/aspirational content (planned CLI, "new service in development") not reflected in the code.

## Test plan
- [x] Read README.md renders correctly (markdown headings, code blocks, lists)
- [x] Verified every claim against source: main.go files, shared/task, shared/flags, migrations/*.sql, docker-compose.yaml, makefile, frontend/package.json and src structure, python-scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)