### PR TITLE
[Security] Audit and fix vulnerabilities

### DIFF
--- a/api/dockerfile
+++ b/api/dockerfile
@@ -14,10 +14,14 @@ RUN cd api && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '
 
 FROM alpine
 
+RUN addgroup -S app && adduser -S app -G app
+
 COPY --from=build /go/bin/api /app/
 COPY --from=build /app/api/.env /app/.env
 COPY --from=build /app/shared/.env /app/shared/.env
 
 WORKDIR /app
+RUN chown -R app:app /app
+USER app
 
 CMD ["./api"]

--- a/api/pkg/handlers/app_integration.go
+++ b/api/pkg/handlers/app_integration.go
@@ -8,12 +8,16 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/verasthiago/verancial/api/pkg/builder"
+	"github.com/verasthiago/verancial/shared/auth"
 	"github.com/verasthiago/verancial/shared/constants"
 	"github.com/verasthiago/verancial/shared/types"
 )
 
 type AppIntegrationRequest struct {
-	UserId              string `json:"userid"`
+	// UserId is intentionally not read from client input. It is derived
+	// from the authenticated JWT to prevent IDOR (a user requesting
+	// integration data/actions on another user's behalf).
+	UserId              string `json:"-"`
 	AppID               string `json:"appid"`
 	BankId              string `json:"bankid"`
 	LastTransactionData string `json:"lasttransactiondate"`
@@ -38,7 +42,13 @@ func (a *AppIntegrationHandler) Handler(context *gin.Context) error {
 	if err := context.ShouldBindJSON(&request); err != nil {
 		return err
 	}
-	fmt.Printf("\nrequest %+v\n", request)
+
+	userObj, _ := context.Get("user")
+	user, ok := userObj.(*auth.UserClaims)
+	if !ok || user == nil || user.ID == "" {
+		return fmt.Errorf("unauthorized")
+	}
+	request.UserId = user.ID
 
 	if request.AsyncProcessing {
 		return a.HandlerAsync(request, context)

--- a/api/pkg/handlers/bank.go
+++ b/api/pkg/handlers/bank.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/verasthiago/verancial/api/pkg/builder"
+	"github.com/verasthiago/verancial/shared/auth"
 	"github.com/verasthiago/verancial/shared/models"
 )
 
@@ -25,7 +26,10 @@ func (h *BankStatsHandler) InitFromBuilder(builder builder.Builder) *BankStatsHa
 
 func (h *BankStatsHandler) Handler(context *gin.Context) error {
 	userObj, _ := context.Get("user")
-	user, _ := userObj.(*models.User)
+	user, ok := userObj.(*auth.UserClaims)
+	if !ok || user == nil {
+		return fmt.Errorf("unauthorized")
+	}
 
 	bankId := context.Param("bankId")
 	if bankId == "" {

--- a/api/pkg/handlers/report_processor.go
+++ b/api/pkg/handlers/report_processor.go
@@ -8,16 +8,39 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
+	"time"
 
 	"encoding/base64"
 
 	"github.com/gin-gonic/gin"
 	"github.com/verasthiago/verancial/api/pkg/builder"
+	"github.com/verasthiago/verancial/shared/auth"
 	"github.com/verasthiago/verancial/shared/types"
 )
 
+// unsafeFileNameChars matches anything that isn't alphanumeric, dot, dash or
+// underscore. Used to strip path separators / traversal sequences out of
+// client-supplied file names before they are used to build a filesystem path.
+var unsafeFileNameChars = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+
+// sanitizeFileName strips directory components and any character that isn't
+// safe for a flat file name, preventing path traversal (e.g. "../../etc/x")
+// when building the temp file path.
+func sanitizeFileName(name string) string {
+	name = filepath.Base(name)
+	name = unsafeFileNameChars.ReplaceAllString(name, "_")
+	if name == "" || name == "." || name == ".." {
+		name = "upload"
+	}
+	return name
+}
+
 type Request struct {
-	UserId          string `json:"userid"`
+	// UserId is intentionally not read from client input. It is derived
+	// from the authenticated JWT to prevent IDOR (a user uploading or
+	// processing a report on another user's behalf).
+	UserId          string `json:"-"`
 	FilePath        string `json:"filepath,omitempty"` // Used internally for DPW service
 	FileData        string `json:"filedata,omitempty"` // Base64 encoded CSV content from web uploads
 	FileName        string `json:"filename,omitempty"` // Original filename from web uploads
@@ -45,6 +68,13 @@ func (r *ReportProcessorHandler) Handler(context *gin.Context) error {
 		return err
 	}
 
+	userObj, _ := context.Get("user")
+	user, ok := userObj.(*auth.UserClaims)
+	if !ok || user == nil || user.ID == "" {
+		return fmt.Errorf("unauthorized")
+	}
+	request.UserId = user.ID
+
 	// Process the uploaded file
 	tempFilePath, err := r.handleFileUpload(request)
 	if err != nil {
@@ -69,12 +99,22 @@ func (r *ReportProcessorHandler) handleFileUpload(request Request) (string, erro
 		return "", fmt.Errorf("failed to decode file data: %v", err)
 	}
 
-	// Create temporary file
+	// Create temporary file. Both the user ID (from the authenticated JWT)
+	// and the file name (from client input) are sanitized to plain,
+	// flat-path-safe tokens before being joined onto tempDir, preventing
+	// path traversal via a crafted "filename" (e.g. "../../etc/passwd").
 	tempDir := os.TempDir()
-	tempFilePath := filepath.Join(tempDir, fmt.Sprintf("upload_%s_%s", request.UserId, request.FileName))
+	safeUserId := sanitizeFileName(request.UserId)
+	safeFileName := sanitizeFileName(request.FileName)
+	tempFilePath := filepath.Join(tempDir, fmt.Sprintf("upload_%s_%s", safeUserId, safeFileName))
+
+	// Defense in depth: ensure the resolved path is still inside tempDir.
+	if rel, err := filepath.Rel(tempDir, tempFilePath); err != nil || rel == ".." || len(rel) >= 2 && rel[:2] == ".." {
+		return "", fmt.Errorf("invalid file path")
+	}
 
 	// Write decoded data to temporary file
-	if err := ioutil.WriteFile(tempFilePath, fileData, 0644); err != nil {
+	if err := ioutil.WriteFile(tempFilePath, fileData, 0600); err != nil {
 		return "", fmt.Errorf("failed to write temporary file: %v", err)
 	}
 
@@ -120,7 +160,7 @@ func (r *ReportProcessorHandler) processSync(request Request, tempFilePath strin
 
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: 5 * time.Minute}
 	resp, err := client.Do(req)
 	if err != nil {
 		return err

--- a/api/pkg/handlers/transaction/list.go
+++ b/api/pkg/handlers/transaction/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/verasthiago/verancial/api/pkg/builder"
+	"github.com/verasthiago/verancial/shared/auth"
 	"github.com/verasthiago/verancial/shared/models"
 )
 
@@ -36,7 +37,10 @@ func (h *ListTransactionsHandler) InitFromBuilder(builder builder.Builder) *List
 
 func (h *ListTransactionsHandler) Handler(c *gin.Context) error {
 	userObj, _ := c.Get("user")
-	user, _ := userObj.(*models.User)
+	user, ok := userObj.(*auth.UserClaims)
+	if !ok || user == nil {
+		return fmt.Errorf("unauthorized")
+	}
 
 	var req ListTransactionsRequest
 	if err := c.ShouldBindUri(&req); err != nil {

--- a/api/pkg/middlewares/auth.go
+++ b/api/pkg/middlewares/auth.go
@@ -45,6 +45,7 @@ func (a *AuthUserHandler) Handler() gin.HandlerFunc {
 			return
 		}
 		context.Set("user", jwtClaim.User)
+		context.Set("userId", jwtClaim.User.ID)
 		context.Next()
 	}
 }

--- a/app-integration-worker/dockerfile
+++ b/app-integration-worker/dockerfile
@@ -15,10 +15,14 @@ RUN cd app-integration-worker && CGO_ENABLED=0 GOOS=linux go build -a -installsu
 
 FROM alpine
 
+RUN addgroup -S app && adduser -S app -G app
+
 COPY --from=build /go/bin/app-integration-worker /app/
 COPY --from=build /app/app-integration-worker/.env /app/.env
 COPY --from=build /app/shared/.env /app/shared/.env
 
 WORKDIR /app
+RUN chown -R app:app /app
+USER app
 
 CMD ["./app-integration-worker"]

--- a/data-process-worker/dockerfile
+++ b/data-process-worker/dockerfile
@@ -14,10 +14,14 @@ RUN cd data-process-worker && CGO_ENABLED=0 GOOS=linux go build -a -installsuffi
 
 FROM alpine
 
+RUN addgroup -S app && adduser -S app -G app
+
 COPY --from=build /go/bin/data-process-worker /app/
 COPY --from=build /app/data-process-worker/.env /app/.env
 COPY --from=build /app/shared/.env /app/shared/.env
 
 WORKDIR /app
+RUN chown -R app:app /app
+USER app
 
 CMD ["./data-process-worker"]

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -139,25 +139,15 @@ class ApiService {
   }
 
   async uploadStatement(request: UploadStatementRequest): Promise<void> {
-    // Get the current user token to extract user ID
-    const token = this.getToken();
-    if (!token) {
+    if (!this.isAuthenticated()) {
       throw new Error('No authentication token found');
     }
 
-    // Decode JWT token to get user ID (simple base64 decode of payload)
-    const payload = JSON.parse(atob(token.split('.')[1]));
-    
-    // Based on the Go JWT structure: JWTClaim has User field with ID
-    const userId = payload.User?.id;
-
-    if (!userId) {
-      console.error('JWT payload structure:', payload);
-      throw new Error('User ID not found in token. Expected User.id field.');
-    }
-
+    // The user ID is derived server-side from the authenticated request
+    // (Authorization header), never from client-supplied input. This avoids
+    // exposing/relying on JWT internals in the browser and prevents a
+    // malicious client from acting on another user's behalf.
     const reportRequest = {
-      userid: userId,
       filedata: request.fileData,
       filename: request.fileName,
       bankid: request.bankId,

--- a/login/dockerfile
+++ b/login/dockerfile
@@ -14,10 +14,14 @@ RUN cd login && CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags
 
 FROM alpine
 
+RUN addgroup -S app && adduser -S app -G app
+
 COPY --from=build /go/bin/login /app/
 COPY --from=build /app/login/.env /app/.env
 COPY --from=build /app/shared/.env /app/shared/.env
 
 WORKDIR /app
+RUN chown -R app:app /app
+USER app
 
 CMD ["./login"]

--- a/shared/auth/auth.go
+++ b/shared/auth/auth.go
@@ -2,20 +2,40 @@ package auth
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/verasthiago/verancial/shared/models"
 )
 
+// UserClaims holds only the minimal, non-sensitive user information that is
+// safe to embed in a JWT. JWTs are base64-encoded, NOT encrypted, so secrets
+// such as the password hash or bank/financial app credentials must never be
+// placed here.
+type UserClaims struct {
+	ID      string `json:"id"`
+	IsAdmin bool   `json:"isadmin"`
+}
+
 type JWTClaim struct {
-	User *models.User
+	User *UserClaims
 	jwt.StandardClaims
+}
+
+func userClaimsFromUser(user *models.User) *UserClaims {
+	if user == nil {
+		return nil
+	}
+	return &UserClaims{
+		ID:      user.ID,
+		IsAdmin: user.IsAdmin,
+	}
 }
 
 func GenerateJWT(user *models.User, jwtKey string, expirationTime time.Time) (string, error) {
 	claims := &JWTClaim{
-		User: user,
+		User: userClaimsFromUser(user),
 		StandardClaims: jwt.StandardClaims{
 			ExpiresAt: expirationTime.Unix(),
 		},
@@ -44,6 +64,11 @@ func GetJWTClaimFromToken(signedToken, jwtKey string) (*JWTClaim, error) {
 		signedToken,
 		&JWTClaim{},
 		func(token *jwt.Token) (interface{}, error) {
+			// Reject tokens signed with an unexpected algorithm (e.g. "none")
+			// to prevent algorithm-confusion / signature-bypass attacks.
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
 			return []byte(jwtKey), nil
 		},
 	)
@@ -54,6 +79,10 @@ func GetJWTClaimFromToken(signedToken, jwtKey string) (*JWTClaim, error) {
 	claims, ok := token.Claims.(*JWTClaim)
 	if !ok {
 		return nil, errors.New("couldn't parse claims")
+	}
+
+	if claims.User == nil {
+		return nil, errors.New("token missing user claims")
 	}
 
 	return claims, nil


### PR DESCRIPTION
## Summary

Security audit of the Verancial monorepo (Go services in `api/`, `login/`, `app-integration-worker/`, `data-process-worker/`, `shared/`; `frontend/`; `migrations/`; `python-scripts/`; Docker setup). This PR fixes everything found that could be fixed without a larger architectural change; remaining items are listed as follow-ups at the bottom.

## Findings and fixes

### 1. CRITICAL — Sensitive data embedded in JWT payload
**Where:** `shared/auth/auth.go` (`JWTClaim` wrapped the full `*models.User`)
**Issue:** JWTs are base64url-encoded, not encrypted. The full `User` struct — including the bcrypt password hash (`Password` field), and (when populated) `BankCredentials`/`FinancialAppCredentials` (the user's actual online-banking login/password, see `shared/models/bank_credentials.go`) — was embedded directly in every issued token via `json` tags on those fields. Anyone who intercepts a token, or has access to the browser's `localStorage` (e.g. via an XSS bug, a malicious browser extension, or a shared/compromised device), can trivially base64-decode the token and read the user's bank password and password hash. The frontend (`frontend/src/services/api.ts`) was also decoding this payload client-side, and on failure logged the full decoded payload — including these secrets — to the browser console (`console.error('JWT payload structure:', payload)`).
**Fix:** Replaced the embedded `*models.User` with a minimal `UserClaims{ID, IsAdmin}` struct in `shared/auth/auth.go`. Updated all consumers (`api/pkg/middlewares/auth.go`, `api/pkg/handlers/bank.go`, `api/pkg/handlers/transaction/list.go`, `api/pkg/handlers/app_integration.go`, `api/pkg/handlers/report_processor.go`) to use the new minimal claims. Removed the client-side JWT decoding and the console.error in `frontend/src/services/api.ts`.
**Also fixed in the same function:** `jwt.ParseWithClaims`'s key-lookup callback returned the HMAC key unconditionally without checking `token.Method`, which is the classic JWT "algorithm confusion" pattern (a forged token using `alg: none` or an attacker-chosen asymmetric algorithm could potentially bypass signature verification depending on library behavior). Added an explicit check that `token.Method` is `*jwt.SigningMethodHMAC` before returning the key.

### 2. CRITICAL — IDOR (Broken Object-Level Access Control) in report/app-integration endpoints
**Where:** `api/pkg/handlers/app_integration.go` (`POST /api/v0/app-integration/generate`), `api/pkg/handlers/report_processor.go` (`POST /api/v0/report/process`)
**Issue:** Both routes sit behind JWT auth middleware (token validity is checked), but the handlers read the target `userid` from the client-supplied JSON body rather than from the authenticated identity in the request context. Any authenticated user could pass an arbitrary `userid` and trigger statement-report processing or app-integration report generation against another user's account/data — a direct horizontal-privilege-escalation / IDOR. This is a financial app, so this could be used to pollute another user's transaction history or trigger unwanted external app-integration submissions.
**Fix:** Both handlers now ignore any client-supplied `userid` (`json:"-"` on the struct field) and derive it exclusively from `context.Get("user")`, i.e. the authenticated JWT claim, before constructing downstream requests. The frontend (`frontend/src/services/api.ts`, `uploadStatement`) no longer sends a `userid` field at all.

### 3. HIGH — Path traversal in statement-upload file handling
**Where:** `api/pkg/handlers/report_processor.go` (`handleFileUpload`)
**Issue:** The temp file path was built as `filepath.Join(tempDir, fmt.Sprintf("upload_%s_%s", request.UserId, request.FileName))` where `FileName` is taken verbatim from client JSON input with zero sanitization. A crafted `filename` such as `../../../../some/path` (or an absolute path) could write the decoded statement file outside the intended temp directory, potentially overwriting arbitrary files reachable by the process user.
**Fix:** Added `sanitizeFileName()` which takes `filepath.Base()` of the input and strips any character outside `[a-zA-Z0-9._-]`, applied to both `FileName` and the (now server-derived) `UserId` before building the path. Added a defense-in-depth check that the resolved path is still inside `tempDir` via `filepath.Rel`. Also tightened the written file's permissions from `0644` to `0600` (it transiently contains a bank statement).

### 4. MEDIUM — Containers run as root
**Where:** `api/dockerfile`, `login/dockerfile`, `data-process-worker/dockerfile`, `app-integration-worker/dockerfile`
**Issue:** All four Go-service Dockerfiles' final `alpine` stage ran the application as root (no `USER` directive), which is an unnecessary privilege if the container or a dependency is ever compromised.
**Fix:** Each Dockerfile now creates an unprivileged `app` user/group, `chown`s `/app`, and switches to it with `USER app` before `CMD`.

### 5. Reviewed, no change needed (confirmed safe)
- **SQL injection:** All database access goes through GORM with parameterized `Where("col = ?", val)` calls (`shared/repository/postgresRepository/*.go`); no raw string-concatenated SQL was found anywhere in the Go codebase.
- **RLS policies:** `migrations/run_migrations.sql` and `migrations/002_create_bank_accounts.sql` already enable RLS (`ENABLE ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY`) on `users`, `transactions`, `bank_accounts`, and `user_bank_accounts`, with per-user `current_setting('request.jwt.claims',...)::json->>'sub'` policies and an explicit service-role bypass policy. This is a reasonable, well-structured RLS setup; no gaps found. (Note: the app currently connects via GORM with what appears to be a direct/service-role Postgres connection rather than PostgREST-style per-request JWT claims, so RLS here is a defense-in-depth layer, not the primary access-control mechanism — the application-layer IDOR fixes above are the primary fix.)
- **Repository-layer authorization:** All transaction/bank-account queries in `shared/repository/postgresRepository/{transaction,bank_account}.go` are correctly scoped by `user_id` server-side, so once the handler-layer IDOR (finding #2) is fixed, data access is properly isolated per user.
- **Admin endpoints:** `login`'s `DELETE /admin/delete` and `PUT /admin/update` are correctly gated behind `IsAdmin` middleware (`login/pkg/middlewares/auth_admin.go`); this is an intentional admin-only design, not a vulnerability.
- **Hardcoded secrets:** No secrets/API keys/passwords found hardcoded in source or in `docker-compose.yaml`. `.env` is git-ignored and confirmed not tracked in the repo; secrets are sourced from environment/`.env` files via Viper, consistent with the existing pattern.
- **CORS:** No explicit CORS middleware exists, but the frontend's `nginx.conf` proxies `/api/` and `/login/` same-origin, so the browser app doesn't rely on cross-origin requests in the current deployment topology.

## Follow-ups (not fixed in this PR — flagging for visibility)

- `python-scripts/get_last_transaction_budgetbakers.py` takes the user's bank-app email/password as plain CLI arguments (`sys.argv`), which are visible to other local processes via the process list while the script runs. Fixing this properly means changing how `app-integration-worker` invokes the script (e.g. via stdin or a short-lived env var) and is a larger change than fits a security-patch PR; flagging for a follow-up.
- Content-Security-Policy in `frontend/nginx.conf` is fairly permissive (inline scripts/styles allowed, blanket http/https sources). Tightening this is a UX/build tradeoff better handled as its own change with testing.
- `frontend/dockerfile` (nginx) still runs as root; switching to nginx's unprivileged image variant is possible but wasn't done here to avoid risking the container's ability to bind/serve without further testing — flagging as a follow-up alongside the CSP work.
- Pre-existing, unrelated uncommitted changes already present in the working tree before this audit (UUID-based bank IDs migration, batched transaction inserts in `shared/repository/postgresRepository/*`) were left untouched/unstaged — out of scope for this audit.

## Test plan
- [x] `go build ./...` passes for `api`, `login`, `app-integration-worker`, `data-process-worker`, and `shared`
- [ ] Manual smoke test: sign in, confirm dashboard/bank/transaction endpoints still work with the new minimal JWT claims
- [ ] Manual smoke test: upload a statement and confirm report processing still succeeds end-to-end with the server-derived `userid`
- [ ] Confirm Docker images still build and start correctly as the non-root `app` user (file/socket permissions, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
